### PR TITLE
Adjust map view to show all of Poland

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,7 +41,15 @@ body {
   border-right: 1px solid #e5e7eb;
 }
 
+.map-wrapper {
+  flex: 1;
+  display: flex;
+  background-color: #dfe7ef;
+}
+
 .map-container {
   flex: 1;
-  background-color: #dfe7ef;
+  width: 100%;
+  height: 100%;
+  min-height: 500px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,15 @@
+import { MapContainer, TileLayer } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import './App.css';
 
 function App() {
+  const polandCenter = [52.0976, 19.1451];
+  const polandZoom = 6;
+  const polandBounds = [
+    [48.9965, 14.1229],
+    [54.8356, 24.1458],
+  ];
+
   return (
     <div className="app">
       <header className="app-header">
@@ -9,7 +17,19 @@ function App() {
       </header>
       <div className="app-body">
         <aside className="sidebar" aria-label="Target list" />
-        <main className="map-container" aria-label="Map display" />
+        <main className="map-wrapper" aria-label="Map display">
+          <MapContainer
+            center={polandCenter}
+            zoom={polandZoom}
+            bounds={polandBounds}
+            className="map-container"
+          >
+            <TileLayer
+              attribution="&copy; OpenStreetMap contributors"
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            />
+          </MapContainer>
+        </main>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- widen the map viewport to frame the entirety of Poland by default
- set explicit bounds and zoom so the full country is visible on initial load

## Testing
- npm run build *(fails: react-scripts not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f332cfa0832a80ea4052d87fd1e8