### PR TITLE
Render drone trajectories with distinct call signs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -39,12 +39,64 @@ body {
   width: 320px;
   background-color: #ffffff;
   border-right: 1px solid #e5e7eb;
+  padding: 1.5rem;
+  box-sizing: border-box;
+  overflow-y: auto;
+}
+
+.target-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.target-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  background-color: #f8f9fb;
+  border: 1px solid #e5e7eb;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.risk-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.1);
+}
+
+.target-meta {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.target-meta div {
+  display: flex;
+  gap: 0.35rem;
+}
+
+.target-meta dt {
+  font-weight: 600;
+}
+
+.target-meta dd {
+  margin: 0;
 }
 
 .map-wrapper {
   flex: 1;
   display: flex;
   background-color: #dfe7ef;
+  position: relative;
 }
 
 .map-container {
@@ -52,4 +104,77 @@ body {
   width: 100%;
   height: 100%;
   min-height: 500px;
+}
+
+.map-legend {
+  position: absolute;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  background-color: rgba(255, 255, 255, 0.95);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.2);
+  min-width: 180px;
+}
+
+.map-legend h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.map-legend ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.map-legend li {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.legend-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.15);
+}
+
+.legend-footnote {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #e5e7eb;
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+.legend-entry {
+  display: inline-flex;
+  align-items: center;
+}
+
+.legend-start,
+.legend-end {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  margin-right: 0.35rem;
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.15);
+}
+
+.legend-start {
+  background: #ffffff;
+}
+
+.legend-end {
+  background: linear-gradient(135deg, #2f9e44, #f08c00, #c92a2a);
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,31 @@
-import { MapContainer, TileLayer } from 'react-leaflet';
+import { Fragment } from 'react';
+import { MapContainer, TileLayer, Popup, Polyline, CircleMarker } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import './App.css';
+
+const riskColors = {
+  Low: '#2f9e44',
+  Medium: '#f08c00',
+  High: '#c92a2a',
+};
+
+const trajectoryOptions = {
+  weight: 4,
+  opacity: 0.85,
+  dashArray: '6 8',
+  lineCap: 'round',
+};
 
 const rawTargets = [
   {
     id: 1,
-    name: 'Warsaw Central Rogue',
-    lat: 52.2297,
-    lon: 21.0122,
+    track: [
+      [52.2174, 20.9452],
+      [52.2199, 20.967],
+      [52.2231, 20.9894],
+      [52.2274, 21.0026],
+      [52.231, 21.0178],
+    ],
     riskFactors: {
       imeiModem: true,
       dataOnly: true,
@@ -25,9 +43,13 @@ const rawTargets = [
   },
   {
     id: 2,
-    name: 'Łódź Industrial Flyover',
-    lat: 51.7592,
-    lon: 19.455,
+    track: [
+      [51.7387, 19.3578],
+      [51.7459, 19.3846],
+      [51.7506, 19.4122],
+      [51.7558, 19.4367],
+      [51.7622, 19.4613],
+    ],
     riskFactors: {
       imeiModem: true,
       dataOnly: false,
@@ -45,9 +67,13 @@ const rawTargets = [
   },
   {
     id: 3,
-    name: 'Gdańsk Port Surveyor',
-    lat: 54.352,
-    lon: 18.6466,
+    track: [
+      [54.3211, 18.5247],
+      [54.3279, 18.5521],
+      [54.3358, 18.5811],
+      [54.3436, 18.6084],
+      [54.3517, 18.6429],
+    ],
     riskFactors: {
       imeiModem: true,
       dataOnly: true,
@@ -65,9 +91,13 @@ const rawTargets = [
   },
   {
     id: 4,
-    name: 'Poznań Delivery Route',
-    lat: 52.4064,
-    lon: 16.9252,
+    track: [
+      [52.3615, 16.8423],
+      [52.3731, 16.8647],
+      [52.3863, 16.8932],
+      [52.3978, 16.9156],
+      [52.4084, 16.9389],
+    ],
     riskFactors: {
       imeiModem: false,
       dataOnly: false,
@@ -85,9 +115,13 @@ const rawTargets = [
   },
   {
     id: 5,
-    name: 'Kraków Tourist Flight',
-    lat: 50.0647,
-    lon: 19.945,
+    track: [
+      [50.0327, 19.8765],
+      [50.0398, 19.8971],
+      [50.0475, 19.9196],
+      [50.0551, 19.9373],
+      [50.0629, 19.9564],
+    ],
     riskFactors: {
       imeiModem: false,
       dataOnly: false,
@@ -105,9 +139,13 @@ const rawTargets = [
   },
   {
     id: 6,
-    name: 'Rzeszów Border Patrol',
-    lat: 50.0412,
-    lon: 21.9991,
+    track: [
+      [50.0063, 21.9058],
+      [50.0131, 21.9287],
+      [50.0214, 21.9528],
+      [50.0312, 21.9779],
+      [50.0418, 22.0034],
+    ],
     riskFactors: {
       imeiModem: false,
       dataOnly: true,
@@ -148,10 +186,32 @@ function App() {
     [54.8356, 24.1458],
   ];
 
-  const targets = rawTargets.map((target) => ({
-    ...target,
+  const targets = rawTargets.map((target, index) => ({
     ...calculateRiskProfile(target.riskFactors),
+    callSign: `Drone-${String(index + 1).padStart(3, '0')}`,
+    id: target.id,
+    track: target.track,
+    startPosition: target.track[0],
+    endPosition: target.track[target.track.length - 1],
   }));
+
+  const startMarkerOptions = {
+    radius: 6,
+    weight: 2,
+    color: '#1f2933',
+    fillColor: '#ffffff',
+    fillOpacity: 1,
+  };
+
+  const createEndMarkerOptions = (riskLevel) => ({
+    radius: 7,
+    weight: 2,
+    color: '#ffffff',
+    fillColor: riskColors[riskLevel],
+    fillOpacity: 1,
+  });
+
+  const formatCoordinate = ([lat, lon]) => `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
 
   return (
     <div className="app">
@@ -161,10 +221,33 @@ function App() {
       <div className="app-body">
         <aside className="sidebar" aria-label="Target list">
           <h2>Targets</h2>
-          <ul>
+          <ul className="target-list">
             {targets.map((target) => (
               <li key={target.id}>
-                <strong>{target.name}</strong> — {target.riskLevel} Risk (Score: {target.riskScore})
+                <span
+                  className="risk-indicator"
+                  style={{ backgroundColor: riskColors[target.riskLevel] }}
+                  aria-hidden
+                />
+                <div>
+                  <strong>{target.callSign}</strong>
+                  <dl className="target-meta">
+                    <div>
+                      <dt>Risk</dt>
+                      <dd>
+                        {target.riskLevel} · Score {target.riskScore}
+                      </dd>
+                    </div>
+                    <div>
+                      <dt>Start</dt>
+                      <dd>{formatCoordinate(target.startPosition)}</dd>
+                    </div>
+                    <div>
+                      <dt>Last seen</dt>
+                      <dd>{formatCoordinate(target.endPosition)}</dd>
+                    </div>
+                  </dl>
+                </div>
               </li>
             ))}
           </ul>
@@ -180,7 +263,58 @@ function App() {
               attribution="&copy; OpenStreetMap contributors"
               url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             />
+            {targets.map((target) => (
+              <Fragment key={target.id}>
+                <Polyline
+                  positions={target.track}
+                  pathOptions={{
+                    ...trajectoryOptions,
+                    color: riskColors[target.riskLevel],
+                  }}
+                />
+                <CircleMarker center={target.startPosition} pathOptions={startMarkerOptions}>
+                  <Popup>
+                    <strong>{target.callSign}</strong>
+                    <br />
+                    Launch position: {formatCoordinate(target.startPosition)}
+                  </Popup>
+                </CircleMarker>
+                <CircleMarker
+                  center={target.endPosition}
+                  pathOptions={createEndMarkerOptions(target.riskLevel)}
+                >
+                  <Popup>
+                    <strong>{target.callSign}</strong>
+                    <br />
+                    Current position: {formatCoordinate(target.endPosition)}
+                    <br />
+                    Risk: {target.riskLevel} ({target.riskScore})
+                  </Popup>
+                </CircleMarker>
+              </Fragment>
+            ))}
           </MapContainer>
+          <div className="map-legend" aria-label="Risk legend">
+            <h3>Risk Legend</h3>
+            <ul>
+              {Object.entries(riskColors).map(([level, color]) => (
+                <li key={level}>
+                  <span className="legend-swatch" style={{ backgroundColor: color }} aria-hidden />
+                  {level}
+                </li>
+              ))}
+            </ul>
+            <div className="legend-footnote">
+              <span className="legend-entry">
+                <span className="legend-start" aria-hidden />
+                Launch position
+              </span>
+              <span className="legend-entry">
+                <span className="legend-end" aria-hidden />
+                Current position
+              </span>
+            </div>
+          </div>
         </main>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add trajectory coordinates to each drone target and calculate risk-coloured overlays
- render polylines with launch/current markers and anonymised drone call signs on the map and sidebar
- extend the map legend and target list styling to explain start/end markers and coordinate metadata

## Testing
- npm test -- --watchAll=false *(fails: react-leaflet ESM build requires additional Jest transform configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f7d98768832a8e5cf3badfab3cab