### PR TITLE
Add expandable risk breakdown for target details

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,7 +56,7 @@ body {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.75rem;
-  align-items: center;
+  align-items: flex-start;
   background-color: #f8f9fb;
   border: 1px solid #e5e7eb;
   border-radius: 0.75rem;
@@ -69,6 +69,41 @@ body {
   height: 12px;
   border-radius: 999px;
   box-shadow: 0 0 0 2px rgba(15, 23, 42, 0.1);
+}
+
+.target-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.target-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.details-button {
+  background: #1f2933;
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.details-button:hover,
+.details-button:focus-visible {
+  background: #111827;
+}
+
+.details-button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
 }
 
 .target-meta {
@@ -90,6 +125,37 @@ body {
 
 .target-meta dd {
   margin: 0;
+}
+
+.factor-breakdown {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0 0 0;
+  border-top: 1px solid #e5e7eb;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: #1f2933;
+}
+
+.factor-breakdown li {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.factor-label {
+  font-weight: 500;
+}
+
+.factor-result {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  color: #475569;
+}
+
+.factor-points {
+  color: #1f2933;
 }
 
 .map-wrapper {


### PR DESCRIPTION
## Summary
- add stateful details toggle to show risk factor breakdown per target
- display weighted factor contributions with descriptive labels in the sidebar
- style the details button and breakdown list for clearer presentation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e0fe572704832a8d07cd1b969fc202