### PR TITLE
Add mitigation controls and feedback for drone actions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -52,7 +52,7 @@ body {
   gap: 1rem;
 }
 
-.target-list li {
+.target-card {
   display: grid;
   grid-template-columns: auto 1fr;
   gap: 0.75rem;
@@ -62,6 +62,11 @@ body {
   border-radius: 0.75rem;
   padding: 0.75rem 1rem;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+}
+
+.target-card--active {
+  border-color: #2563eb;
+  box-shadow: 0 4px 16px rgba(37, 99, 235, 0.25);
 }
 
 .risk-indicator {
@@ -165,6 +170,10 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.action-panel--inline {
+  margin-top: 0.5rem;
 }
 
 .action-panel h4 {
@@ -394,4 +403,111 @@ body {
 .action-tooltip-label {
   font-weight: 600;
   margin-bottom: 0.25rem;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 1500;
+  backdrop-filter: blur(2px);
+}
+
+.modal {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  width: min(520px, 100%);
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+}
+
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.modal-title-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.modal-title-group .risk-indicator {
+  box-shadow: none;
+  width: 14px;
+  height: 14px;
+}
+
+.modal-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.modal-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.modal-close {
+  background: transparent;
+  border: none;
+  color: #1f2933;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+}
+
+.modal-close:hover,
+.modal-close:focus-visible {
+  background: rgba(37, 99, 235, 0.1);
+}
+
+.modal-close:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.modal-body {
+  margin-top: 1.25rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.modal-body h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #1f2933;
+}
+
+.modal-meta {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+}
+
+.modal-meta div {
+  display: flex;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.modal-meta dt {
+  font-weight: 600;
+}
+
+.modal-meta dd {
+  margin: 0;
+  color: #1f2933;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -65,11 +65,32 @@ body {
   border-radius: 0.75rem;
   padding: 0.75rem 1rem;
   box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease,
+    background-color 0.2s ease;
+  user-select: none;
+}
+
+.target-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(15, 23, 42, 0.15);
+}
+
+.target-card:focus-visible {
+  outline: 3px solid rgba(14, 165, 233, 0.55);
+  outline-offset: 2px;
+}
+
+.target-card--selected {
+  border-color: #0ea5e9;
+  background-color: #f0f9ff;
+  box-shadow: 0 6px 18px rgba(14, 165, 233, 0.18);
 }
 
 .target-card--active {
   border-color: #2563eb;
   box-shadow: 0 4px 16px rgba(37, 99, 235, 0.25);
+  background-color: #eff6ff;
 }
 
 .risk-indicator {
@@ -187,7 +208,7 @@ body {
 
 .action-buttons {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.5rem;
 }
 
@@ -310,6 +331,56 @@ body {
   flex: 1;
   width: 100%;
   height: 100%;
+}
+
+.trajectory {
+  transition: filter 0.3s ease, stroke-width 0.3s ease, stroke-opacity 0.3s ease;
+}
+
+.trajectory--selected {
+  animation: trajectoryPulse 1.2s ease-in-out infinite;
+  filter: drop-shadow(0 0 10px rgba(14, 165, 233, 0.45));
+}
+
+@keyframes trajectoryPulse {
+  0% {
+    stroke-width: 6px;
+    stroke-opacity: 1;
+  }
+
+  50% {
+    stroke-width: 3px;
+    stroke-opacity: 0.35;
+  }
+
+  100% {
+    stroke-width: 6px;
+    stroke-opacity: 1;
+  }
+}
+
+.drone-marker {
+  transition: stroke-width 0.3s ease, stroke 0.3s ease;
+}
+
+.drone-marker--selected {
+  animation: markerPulse 1.2s ease-in-out infinite;
+  stroke: #0ea5e9 !important;
+  stroke-width: 4px !important;
+}
+
+@keyframes markerPulse {
+  0% {
+    stroke-opacity: 1;
+  }
+
+  50% {
+    stroke-opacity: 0.4;
+  }
+
+  100% {
+    stroke-opacity: 1;
+  }
 }
 
 .map-legend {

--- a/src/App.css
+++ b/src/App.css
@@ -158,11 +158,135 @@ body {
   color: #1f2933;
 }
 
+.action-panel {
+  margin-top: 0.75rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid #e5e7eb;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.action-panel h4 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #1f2933;
+}
+
+.action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.action-button {
+  border: none;
+  border-radius: 0.5rem;
+  padding: 0.45rem 0.85rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.15);
+}
+
+.action-button:focus-visible {
+  outline: 2px solid #0ea5e9;
+  outline-offset: 2px;
+}
+
+.action-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  box-shadow: none;
+}
+
+.action-button--blue {
+  background: #1d4ed8;
+}
+
+.action-button--blue:hover:not(:disabled),
+.action-button--blue:focus-visible:not(:disabled) {
+  background: #1e40af;
+  transform: translateY(-1px);
+}
+
+.action-button--red {
+  background: #b91c1c;
+}
+
+.action-button--red:hover:not(:disabled),
+.action-button--red:focus-visible:not(:disabled) {
+  background: #991b1b;
+  transform: translateY(-1px);
+}
+
+.action-status {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.65rem;
+  font-size: 0.8rem;
+  line-height: 1.35;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+}
+
+.action-status--success {
+  background: rgba(34, 197, 94, 0.12);
+  color: #166534;
+}
+
+.action-status--error {
+  background: rgba(248, 113, 113, 0.18);
+  color: #991b1b;
+}
+
+.action-status-label {
+  font-weight: 600;
+}
+
+.action-status-message {
+  display: block;
+}
+
 .map-wrapper {
   flex: 1;
   display: flex;
   background-color: #dfe7ef;
   position: relative;
+}
+
+.action-toast {
+  position: absolute;
+  top: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.25);
+  min-width: 260px;
+  z-index: 1000;
+}
+
+.action-toast strong {
+  font-size: 0.9rem;
+}
+
+.action-toast span {
+  font-size: 0.8rem;
+}
+
+.action-toast--success {
+  border-left: 4px solid #16a34a;
+}
+
+.action-toast--error {
+  border-left: 4px solid #dc2626;
 }
 
 .map-container {
@@ -243,4 +367,31 @@ body {
 
 .legend-end {
   background: linear-gradient(135deg, #2f9e44, #f08c00, #c92a2a);
+}
+
+.action-tooltip {
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.35);
+  color: #ffffff;
+}
+
+.action-tooltip--success {
+  background: rgba(22, 101, 52, 0.92);
+}
+
+.action-tooltip--error {
+  background: rgba(185, 28, 28, 0.92);
+}
+
+.action-tooltip span {
+  display: block;
+  font-size: 0.75rem;
+  line-height: 1.25;
+}
+
+.action-tooltip-label {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -207,8 +207,8 @@ body {
 }
 
 .action-buttons {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 0.5rem;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -9,12 +9,13 @@ body {
     sans-serif;
   background-color: #f1f3f5;
   color: #1f2933;
+  overflow: hidden;
 }
 
 .app {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100vh;
 }
 
 .app-header {
@@ -33,6 +34,7 @@ body {
   display: flex;
   flex: 1;
   min-height: 0;
+  overflow: hidden;
 }
 
 .sidebar {
@@ -42,6 +44,7 @@ body {
   padding: 1.5rem;
   box-sizing: border-box;
   overflow-y: auto;
+  height: 100%;
 }
 
 .target-list {
@@ -183,8 +186,8 @@ body {
 }
 
 .action-buttons {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 0.5rem;
 }
 
@@ -198,6 +201,9 @@ body {
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   box-shadow: 0 2px 6px rgba(15, 23, 42, 0.15);
+  width: 100%;
+  justify-self: stretch;
+  text-align: center;
 }
 
 .action-button:focus-visible {
@@ -264,6 +270,8 @@ body {
   display: flex;
   background-color: #dfe7ef;
   position: relative;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .action-toast {
@@ -302,7 +310,6 @@ body {
   flex: 1;
   width: 100%;
   height: 100%;
-  min-height: 500px;
 }
 
 .map-legend {

--- a/src/App.js
+++ b/src/App.js
@@ -625,7 +625,6 @@ function App() {
             maxBounds={regionalBounds}
             maxBoundsViscosity={1}
             className="map-container"
-            scrollWheelZoom={false}
           >
             <TileLayer
               attribution="&copy; OpenStreetMap contributors"


### PR DESCRIPTION
## Summary
- add mitigation action metadata for each drone and surface SIM Detach, Cyber Takeover, and Directional Jam controls with contextual messaging
- highlight mitigated drones with blue trajectories, permanent map callouts, and an updated legend plus transient toast notifications
- style new action controls and feedback elements for consistent blue/red/green states

## Testing
- npm test -- --watch=false *(fails: react-leaflet ESM modules are not transformed under Jest in this setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e10dd9b7f8832a9921847a4486afee