### PR TITLE
Add downloadable audit log with engagement summary

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -23,11 +23,45 @@ body {
   color: #ffffff;
   padding: 1.5rem 2rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
 }
 
 .app-header h1 {
   margin: 0;
   font-size: 1.5rem;
+}
+
+.download-button {
+  background: linear-gradient(135deg, #22c55e, #16a34a);
+  color: #ffffff;
+  border: none;
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.download-button:hover,
+.download-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(22, 163, 74, 0.35);
+  background: linear-gradient(135deg, #16a34a, #15803d);
+}
+
+.download-button:focus-visible {
+  outline: 2px solid rgba(34, 197, 94, 0.6);
+  outline-offset: 3px;
+}
+
+.download-button:active {
+  transform: translateY(0);
+  box-shadow: 0 3px 10px rgba(21, 128, 61, 0.4);
 }
 
 .app-body {


### PR DESCRIPTION
## Summary
- track operator actions per target to build engagement statistics
- generate a downloadable text-based audit log with summary and detailed entries
- style the dashboard header with a prominent download control

## Testing
- npm test -- --watchAll=false *(fails: Jest cannot parse ESM exports from react-leaflet)*

------
https://chatgpt.com/codex/tasks/task_e_68e12894eb1c832a80ee9080bcf7b248