### PR TITLE
Wrap formatCoordinate in useCallback

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -537,7 +537,10 @@ function App() {
     className: 'drone-marker',
   };
 
-  const formatCoordinate = ([lat, lon]) => `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
+  const formatCoordinate = useCallback(
+    ([lat, lon]) => `${lat.toFixed(4)}, ${lon.toFixed(4)}`,
+    []
+  );
 
   const legendItems = [
     ...Object.entries(riskColors).map(([level, color]) => ({


### PR DESCRIPTION
## Summary
- wrap the formatCoordinate helper in useCallback to keep a stable reference for hook dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e13fd54734832aa3fce77407099542