### PR TITLE
Disable reused drone actions and reorder completed targets

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -342,6 +342,15 @@ body {
   box-shadow: none;
 }
 
+.action-button--deactivated {
+  background: #475569;
+  color: #e2e8f0;
+}
+
+.action-button--deactivated:disabled {
+  opacity: 1;
+}
+
 .action-button--blue {
   background: #1d4ed8;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -343,8 +343,8 @@ body {
 }
 
 .action-button--deactivated {
-  background: #475569;
-  color: #e2e8f0;
+  background: #9ca3af;
+  color: #1f2937;
 }
 
 .action-button--deactivated:disabled {

--- a/src/App.css
+++ b/src/App.css
@@ -342,15 +342,6 @@ body {
   box-shadow: none;
 }
 
-.action-button--deactivated {
-  background: #9ca3af;
-  color: #1f2937;
-}
-
-.action-button--deactivated:disabled {
-  opacity: 1;
-}
-
 .action-button--blue {
   background: #1d4ed8;
 }
@@ -379,6 +370,22 @@ body {
 .action-button--green:focus-visible:not(:disabled) {
   background: #15803d;
   transform: translateY(-1px);
+}
+
+.action-button.action-button--deactivated {
+  background: #9ca3af;
+  color: #1f2937;
+}
+
+.action-button.action-button--deactivated:hover:not(:disabled),
+.action-button.action-button--deactivated:focus-visible:not(:disabled) {
+  background: #9ca3af;
+  color: #1f2937;
+  transform: none;
+}
+
+.action-button.action-button--deactivated:disabled {
+  opacity: 1;
 }
 
 .action-status {


### PR DESCRIPTION
## Summary
- track used mitigation actions per drone so buttons deactivate after being executed and completed drones are moved to the end of the list
- grey out deactivated actions with new styling to communicate that they can no longer be triggered

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e147b58308832ab2a0ad520e97224f