### PR TITLE
Add tooltips to drone risk factor breakdown

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -278,7 +278,71 @@ body {
 }
 
 .factor-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   font-weight: 500;
+}
+
+.factor-label__text {
+  display: inline-block;
+}
+
+.factor-help {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 9999px;
+  background-color: #e2e8f0;
+  color: #1f2937;
+  font-size: 0.7rem;
+  font-weight: 600;
+  cursor: help;
+  outline: none;
+}
+
+.factor-help:focus-visible {
+  box-shadow: 0 0 0 2px #94a3b8;
+}
+
+.factor-help__tooltip {
+  position: absolute;
+  z-index: 10;
+  bottom: calc(100% + 0.35rem);
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 16rem;
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.35rem;
+  background-color: #111827;
+  color: #f9fafb;
+  font-size: 0.7rem;
+  line-height: 1.2;
+  text-align: left;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.25);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+}
+
+.factor-help__tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 6px;
+  border-style: solid;
+  border-color: #111827 transparent transparent transparent;
+}
+
+.factor-help:hover .factor-help__tooltip,
+.factor-help:focus-visible .factor-help__tooltip,
+.factor-help:active .factor-help__tooltip {
+  opacity: 1;
 }
 
 .factor-result {

--- a/src/App.js
+++ b/src/App.js
@@ -429,6 +429,35 @@ const riskFactorDetails = {
   noSpeedChangeWaterLand: 'Consistent speed transitioning water ↔ land',
 };
 
+const riskFactorDescriptions = {
+  imeiModem:
+    'The cellular signature aligns with an IoT modem, which is typical for remote-control telemetry rather than a consumer handset.',
+  dataOnly:
+    'The SIM communicates using data-only service, pointing to a command-and-control link without normal voice or SMS activity.',
+  highSpeed:
+    'Ground track shows sustained high velocity, increasing the likelihood of a powered unmanned aircraft.',
+  highHandover:
+    'The device is rapidly roaming between cells, matching an airborne platform traversing multiple sectors.',
+  verticalMovement:
+    'Cell measurements indicate notable altitude changes, suggesting significant climb or descent.',
+  inNoFlyZone:
+    'The trajectory intersects a restricted or prohibited airspace where drone operations are not authorised.',
+  uasFlag:
+    'Network metadata already tags this subscriber as an unmanned aerial system asset.',
+  loitering:
+    'Movement pattern reveals dwell or circular loitering behaviour, often tied to surveillance missions.',
+  highAltitude:
+    'Reported altitude exceeds the expected range for hobbyist drones, elevating risk to other airspace users.',
+  missingRID:
+    'No Remote ID broadcast is detected, violating identification requirements and obscuring accountability.',
+  repeatSighting:
+    'This device has been observed in prior incidents, indicating persistent or deliberate activity.',
+  nearMannedCorridor:
+    'Flight path is close to established manned-aviation corridors, heightening collision hazards.',
+  noSpeedChangeWaterLand:
+    'Speed remains constant while transitioning between water and land sectors, signalling autonomous guidance.',
+};
+
 const computeRisk = (riskFactors) => {
   const riskScore = Object.entries(riskWeights).reduce(
     (score, [factor, weight]) => (riskFactors[factor] ? score + weight : score),
@@ -1218,7 +1247,19 @@ function App() {
                     const points = triggered ? weight : 0;
                     return (
                       <li key={factor}>
-                        <span className="factor-label">{riskFactorDetails[factor]}</span>
+                        <span className="factor-label">
+                          <span
+                            className="factor-help"
+                            tabIndex={0}
+                            aria-label={riskFactorDescriptions[factor]}
+                          >
+                            <span aria-hidden>?</span>
+                            <span className="factor-help__tooltip" role="tooltip">
+                              {riskFactorDescriptions[factor]}
+                            </span>
+                          </span>
+                          <span className="factor-label__text">{riskFactorDetails[factor]}</span>
+                        </span>
                         <span className="factor-result">
                           {triggered ? 'Yes' : 'No'}
                           <span className="factor-points">{` (+${points})`}</span>


### PR DESCRIPTION
## Summary
- add contextual question mark icons before each risk factor in the drone detail modal
- display descriptive tooltips for the metrics and style the helper affordances

## Testing
- npm test -- --watchAll=false *(fails: Jest cannot parse ESM build of react-leaflet)*

------
https://chatgpt.com/codex/tasks/task_e_68e158ea17ec832a964f363b56702639