### PR TITLE
Animate completed drone cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -233,6 +233,13 @@ body {
   background-color: #eff6ff;
 }
 
+.target-card--transitioning {
+  pointer-events: none;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.25);
+  border-color: #2563eb;
+  background-color: #eef2ff;
+}
+
 .risk-indicator {
   width: 12px;
   height: 12px;

--- a/src/App.js
+++ b/src/App.js
@@ -1112,7 +1112,7 @@ function App() {
       listItem.classList.add('target-card--transitioning');
       listItem.style.willChange = 'transform';
       listItem.style.zIndex = '10';
-      listItem.style.transition = 'transform 0.8s cubic-bezier(0.22, 0.61, 0.36, 1)';
+      listItem.style.transition = 'transform 2s cubic-bezier(0.22, 0.61, 0.36, 1)';
       listItem.style.transform = 'translateY(0)';
 
       requestAnimationFrame(() => {
@@ -1266,10 +1266,10 @@ function App() {
             className={`layer-toggle${showRadioStations ? ' layer-toggle--active' : ''}`}
             onClick={toggleRadioStations}
             aria-pressed={showRadioStations}
-            aria-label={showRadioStations ? 'Hide mobile intercept nodes' : 'Show mobile intercept nodes'}
-            title={showRadioStations ? 'Hide mobile intercept nodes' : 'Show mobile intercept nodes'}
+            aria-label={showRadioStations ? 'Hide No-Fly Zones' : 'Show No-Fly Zones'}
+            title={showRadioStations ? 'Hide No-Fly Zones' : 'Show No-Fly Zones'}
           >
-            MIN
+            No-Fly Zones
           </button>
           <nav className="risk-filter" aria-label="Filter drones by risk level">
             {riskLevels.map((level) => {


### PR DESCRIPTION
## Summary
- animate drone list items to visibly move to the end when all actions are used
- add transitional styling to highlight cards while they travel down the list

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e21ee4aa10832a974a56f625bcc494