### PR TITLE
Auto-dismiss notify panel for engaged stations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -710,15 +710,16 @@ body {
   right: 1.5rem;
   bottom: 1.5rem;
   background-color: rgba(255, 255, 255, 0.95);
-  border-radius: 0.75rem;
-  padding: 1rem;
-  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.2);
-  min-width: 180px;
+  border-radius: 0.65rem;
+  padding: 0.75rem 0.85rem;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.18);
+  min-width: 150px;
+  z-index: 1200;
 }
 
 .map-legend h3 {
-  margin: 0 0 0.5rem;
-  font-size: 1rem;
+  margin: 0 0 0.4rem;
+  font-size: 0.9rem;
 }
 
 .map-legend ul {
@@ -726,34 +727,34 @@ body {
   margin: 0;
   padding: 0;
   display: grid;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .map-legend li {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  font-size: 0.9rem;
+  gap: 0.5rem;
+  font-size: 0.8rem;
 }
 
 .legend-swatch {
-  width: 14px;
-  height: 14px;
-  border-radius: 4px;
-  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.15);
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.12);
 }
 
 .legend-footnote {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 0.75rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
-  row-gap: 0.5rem;
-  margin-top: 0.75rem;
-  padding-top: 0.75rem;
+  row-gap: 0.4rem;
+  margin-top: 0.65rem;
+  padding-top: 0.6rem;
   border-top: 1px solid #e5e7eb;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   color: #475569;
 }
 


### PR DESCRIPTION
## Summary
- add dismissal timing so the engaged station notify panel closes a second after sending a notification
- guard the station panel to only render for stations with tracked drones and reset pending dismiss timers when switching nodes
- shrink the risk legend footprint with tighter spacing and sizing

## Testing
- not run (npm test -- --watchAll=false)

------
https://chatgpt.com/codex/tasks/task_e_68e232a38f34832a95fb61d49ca2dca2