### PR TITLE
Fix radio coverage animation activation in production

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1564,8 +1564,12 @@ function App() {
                   .filter(Boolean)
                   .join(' ');
 
+                const coverageKey = `${station.id}-${
+                  isStationEngaged ? 'engaged' : 'idle'
+                }-${isActiveStation ? 'selected' : 'default'}`;
+
                 return (
-                  <Fragment key={station.id}>
+                  <Fragment key={coverageKey}>
                     {notifyingStations.has(station.id) && (
                       <Marker
                         position={station.position}


### PR DESCRIPTION
## Summary
- change the radio coverage circle key to include engagement state so the Leaflet layer remounts when the status flips
- ensure the active/selected CSS class is re-applied so the Netlify build shows the flashing animation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e23443b2cc832a86fc52fc2729f71c